### PR TITLE
Updated Ninject dependency

### DIFF
--- a/SignalR.Ninject/SignalR.Ninject.csproj
+++ b/SignalR.Ninject/SignalR.Ninject.csproj
@@ -36,8 +36,9 @@
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.4.5.5\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Ninject">
-      <HintPath>..\packages\Ninject.2.2.1.4\lib\net40-Full\Ninject.dll</HintPath>
+    <Reference Include="Ninject, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Ninject.3.0.1.10\lib\net40\Ninject.dll</HintPath>
     </Reference>
     <Reference Include="SignalR, Version=0.5.96.10509, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/SignalR.Ninject/packages.config
+++ b/SignalR.Ninject/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="4.5.5" />
-  <package id="Ninject" version="2.2.1.4" />
+  <package id="Ninject" version="3.0.1.10" targetFramework="net40" />
   <package id="SignalR.Server" version="0.5.0" />
 </packages>


### PR DESCRIPTION
Going from Ninject 2.x to 3.x requires you to rebuild. I've updated the NuGet reference to the latest Ninject version. The NuGet package SignalR.Ninject will also need to be redistributed.
